### PR TITLE
fix: promise solidity pragma lower bound

### DIFF
--- a/src/Promise.sol
+++ b/src/Promise.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity ^0.8.0;
 
 import {IL2ToL2CrossDomainMessenger} from "./interfaces/IL2ToL2CrossDomainMessenger.sol";
 import {ICrossL2Inbox, Identifier} from "./interfaces/ICrossL2Inbox.sol";


### PR DESCRIPTION
Any consumer of the promise lib is forced to a specific solidity version